### PR TITLE
docker-compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+ve
+*.pyc
+reports
+celerybeat-schedule

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:trusty
+RUN apt-get update
+RUN apt-get install python-ldap libldap2-dev libsasl2-dev \
+    python-all-dev libxml2-dev libxslt1-dev libjpeg-dev \
+    python-tk liblcms1 libexif-dev libexif12 libfontconfig1-dev \
+    libfreetype6-dev liblcms1-dev libxft-dev python-imaging \
+    python-beautifulsoup python-dev libssl-dev gcc \
+    build-essential binutils libpq-dev postgresql-client -y
+ENV PYTHONUNBUFFERED 1
+RUN apt-get install nodejs npm python-setuptools -y
+RUN easy_install pip
+RUN pip install --upgrade virtualenv
+RUN ln -s /usr/bin/nodejs /usr/local/bin/node
+RUN apt-get install libzmq-dev -y
+RUN mkdir -p /var/www/tala/tala
+COPY requirements.txt /var/www/tala/tala/
+RUN pip install --no-deps -r /var/www/tala/tala/requirements.txt
+WORKDIR /var/www/tala/tala
+COPY . /var/www/tala/tala/
+RUN python manage.py test
+EXPOSE 8000
+ADD docker-run.sh /run.sh
+CMD ["/run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,16 @@ rebase:
 	make migrate
 	make flake8
 
+build:
+	docker build -t ccnmtl/tala .
+
+compose-migrate:
+	docker-compose run web python manage.py migrate --settings=tala.settings_compose
+
+compose-run:
+	docker-compose up
+
+
 # run this one the very first time you check
 # this out on a new machine to set up dev
 # database, etc. You probably *DON'T* want

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+db:
+  image: postgres
+windsock-broker:
+  image: thraxil/windsock-broker
+windsock:
+  image: thraxil/windsock
+  ports:
+    - "5050:5050"
+  links:
+    - windsock-broker
+  volumes:
+    - /etc/nginx/ssl/ccnmtl-wildcard.key:/go/src/github.com/thraxil/windsock/key.pem
+    - /etc/nginx/ssl/ccnmtl-wildcard.pem:/go/src/github.com/thraxil/windsock/cert.pem
+web:
+  build: .
+  command: python manage.py runserver 0.0.0.0:8000 --settings=tala.settings_compose
+  volumes:
+    - .:/var/www/tala/tala
+  ports:
+    - "8000:8000"
+  links:
+    - db
+    - windsock-broker

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd /var/www/tala/tala/
+python manage.py migrate --noinput --settings=tala.settings_docker
+python manage.py collectstatic --noinput --settings=tala.settings_docker
+python manage.py compress --settings=tala.settings_docker
+exec gunicorn --env \
+  DJANGO_SETTINGS_MODULE=tala.settings_docker \
+  tala.wsgi:application -b 0.0.0.0:8000 -w 3 \
+  --access-logfile=- --error-logfile=-

--- a/tala/settings_compose.py
+++ b/tala/settings_compose.py
@@ -1,0 +1,33 @@
+# flake8: noqa
+from settings_shared import *
+
+DEBUG = True
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'HOST': 'db',
+        'PORT': 5432,
+        'ATOMIC_REQUESTS': True,
+    }
+}
+
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+
+WINDSOCK_BROKER_URL = "tcp://windsock-broker:5555"
+ZMQ_APPNAME = "tala"
+WINDSOCK_SECRET = "6f1d916c-7761-4874-8d5b-8f8f93d20bf2"
+
+# browsers are strict about security around SSL certificates
+# and need the host to match up with the certificate
+#
+# you will need to either make an /etc/hosts entry for windsock.ccnmtl
+# pointing to your host, or you will need to make a local_settings.py
+# that overrides this setting with the right hostname.
+WINDSOCK_WEBSOCKETS_BASE = "wss://windsock.ccnmtl.columbia.edu:5050/socket/"
+
+try:
+    from local_settings import *
+except ImportError:
+    pass

--- a/tala/settings_docker.py
+++ b/tala/settings_docker.py
@@ -1,0 +1,91 @@
+# flake8: noqa
+from settings_shared import *
+
+# required settings:
+SECRET_KEY = os.environ['SECRET_KEY']
+BROKER_URL = os.environ['BROKER_URL']
+
+WINDSOCK_BROKER_URL = os.environ['WINDSOCK_BROKER_URL']
+ZMQ_APPNAME = os.environ.get('ZMQ_APPNAME', "tala")
+WINDSOCK_SECRET = os.environ['WINDSOCK_SECRET']
+WINDSOCK_WEBSOCKETS_BASE = os.environ['WINDSOCK_WEBSOCKETS_BASE']
+
+# optional/defaulted settings
+DB_NAME = os.environ.get('DB_NAME', app)
+DB_HOST = os.environ.get(
+    'DB_HOST',
+    os.environ.get('POSTGRESQL_PORT_5432_TCP_ADDR', ''))
+DB_PORT = int(
+    os.environ.get(
+        'DB_PORT',
+        os.environ.get('POSTGRESQL_PORT_54342_TCP_PORT', 5432)))
+DB_USER = os.environ.get('DB_USER', '')
+DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
+
+AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', '')
+AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', '')
+AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY
+AWS_SECRET_ACCESS_KEY = AWS_SECRET_KEY
+
+RAVEN_DSN = os.environ.get('RAVEN_DSN', '')
+
+if 'ALLOWED_HOSTS' in os.environ:
+    ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(',')
+
+TIME_ZONE = os.environ.get('TIME_ZONE', 'America/New_York')
+
+EMAIL_HOST = os.environ.get(
+    'EMAIL_HOST',
+    os.environ.get('POSTFIX_PORT_25_TCP_ADDR', 'localhost'))
+EMAIL_PORT = os.environ.get(
+    'EMAIL_PORT',
+    os.environ.get('POSTFIX_PORT_25_TCP_PORT', 25))
+
+SERVER_EMAIL = os.environ.get('SERVER_EMAIL', app + "@thraxil.org")
+
+# -------------------------------------------
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
+
+TEMPLATE_DIRS = (
+    os.path.join(base, "templates"),
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': DB_NAME,
+        'HOST': DB_HOST,
+        'PORT': DB_PORT,
+        'USER': DB_USER,
+        'PASSWORD': DB_PASSWORD,
+        'ATOMIC_REQUESTS': True,
+        }
+}
+
+if AWS_S3_CUSTOM_DOMAIN:
+    AWS_PRELOAD_METADATA = True
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
+    # static data, e.g. css, js, etc.
+    STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+    STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+    COMPRESS_ENABLED = True
+    COMPRESS_OFFLINE = True
+    COMPRESS_ROOT = STATIC_ROOT
+    COMPRESS_URL = STATIC_URL
+    COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+
+if RAVEN_DSN and 'migrate' not in sys.argv:
+    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
+    RAVEN_CONFIG = {
+        'dsn': RAVEN_DSN,
+    }
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+}


### PR DESCRIPTION
includes windsock websockets server and broker.

Still takes a little bit of extra config because of the SSL certificate
stuff. First, it expects valid ccnmtl-wildcard certificates to be in
`/etc/nginx/ssl` on your host system. Second, it needs you to either add
an entry for `windsock.ccnmtl.columbia.edu` to your /etc/hosts (pointing
to localhost) or include a `local_settings.py` with
`WINDSOCK_WEBSOCKETS_BASE` configured to point at your host. Self-signed
certificates don't seem to work (websockets seem to be super picky about
SSL stuff being set up exactly right).

Otherwise, though, this gives you a way to spin up the whole stack with
one command.