### PR TITLE
remove thumbnail reference from flatpages template

### DIFF
--- a/tala/templates/flatpages/default.html
+++ b/tala/templates/flatpages/default.html
@@ -9,7 +9,6 @@
 
 
 {% load markup %}
-{% load thumbnail %}
 
 {% block title %}{{ flatpage.title }}{% endblock %}
 


### PR DESCRIPTION
compress offline complains about this one.